### PR TITLE
typeof null is also an object

### DIFF
--- a/backbone.rpc2.js
+++ b/backbone.rpc2.js
@@ -155,7 +155,7 @@
 
 			$.each(params, function(param, attribute) {
 				// if this attrbite is an object (or an array), we should recurse into it any update its attributes
-				if (typeof attribute === 'object') {
+				if (typeof attribute === 'object' && attribute) {
 					attribute = model.recursivelySetParams(attribute);
 
 				} else if (typeof attribute === 'string') {


### PR DESCRIPTION
If attribute here is 'null' the if statement passes because typeof null is also 'object'. This results in an error at the $.each loop.